### PR TITLE
Use case para controle de tráfego do pedágio

### DIFF
--- a/use-cases/usecase-01-traffic-control.md
+++ b/use-cases/usecase-01-traffic-control.md
@@ -1,5 +1,7 @@
 # Carro se aproxima e Pedágio decide se libera passagem
 
+Revisão: 2023-09-29
+
 Diagrama
 
 ```mermaid

--- a/use-cases/usecase-01-traffic-control.md
+++ b/use-cases/usecase-01-traffic-control.md
@@ -1,0 +1,20 @@
+# Carro se aproxima e Pedágio decide se libera passagem
+
+Diagrama
+
+```mermaid
+sequenceDiagram
+    Simulador->>Pedagio: carro aproxima (tag)
+    Pedagio->>Pedagio: verifica
+    Pedagio->>Simulador: status {catraca:aberta}
+```
+
+# Descrição
+
+O simulador de tráfego enviará requisições para sinalizar que um carro se aproximou do pedágio e aguarda um status de abertura da cancela.
+
+# Requerimentos técnicos
+
+- requisição http ou grpc para o serviço do pedágio
+  - envia: tag do carro
+  - aguarda: status de abertura da cancela


### PR DESCRIPTION
## Revisão de Pull Request - Documentação

### Descrição

Propõe o use case básico do pedágio: carro aproxima e após decisão, pedágio controla catraca.

closes #13

### Observações

Esse é apenas um documento, as implementações ficarão em repos separados.
[Simulador](https://github.com/dose-na-nuvem/traffic-simulator)
[Pedágio](https://github.com/dose-na-nuvem/toll-station)


## Issue Relacionada

- Número da issue relacionada: #13
